### PR TITLE
Extract metadata from directory name

### DIFF
--- a/m4bify.sh
+++ b/m4bify.sh
@@ -274,19 +274,23 @@ function add_cover_image {
 
 function add_metadata {
   local m4b_file=$1 source_dir=$2 temp_dir=$3
-  local dir_name=$(basename "${source_dir%/}")
-  local author title date
+  local dir_name author title date
 
-  regex_1='^(.+) [-:_] (.+) \(([0-9]{4})\)$'  # "Author Name - Book Title (1939)"
-  regex_2='^(.+) [-:_] (.+) \[([0-9]{4})\]$'  # "Author Name _ Book Title [1939]"
-  regex_3='^(.+) [-:_] (.+)$'                 # "Author Name : Book Title"
+  local regex_1='^(.+) [-:_] (.+) \(([0-9]{4})\)$'  # "Author Name - Book Title (1939)"
+  local regex_2='^(.+) [-:_] (.+) \[([0-9]{4})\]$'  # "Author Name _ Book Title [1939]"
+  local regex_3='^(.+) \(([0-9]{4})\)$'             # "Book Title (1939)"
+  local regex_4='^(.+) \[([0-9]{4})\]$'             # "Book Title [1939]"
+  local regex_5='^(.+) [-:_] (.+)$'                 # "Author Name : Book Title"
 
   echo -e "\n${COLORS[ACTION]}Extracting metadata...${NC}"
+  dir_name=$(basename "${source_dir%/}")
 
   # Try to extract audiobook metadata from directory name
   if [[ ${dir_name} =~ ${regex_1} || ${dir_name} =~ ${regex_2} ]]; then
     author="${BASH_REMATCH[1]}"; title="${BASH_REMATCH[2]}"; date="${BASH_REMATCH[3]}"
-  elif [[ ${dir_name} =~ ${regex_3} ]]; then
+  elif [[ ${dir_name} =~ ${regex_3} || ${dir_name} =~ ${regex_4} ]]; then
+    title="${BASH_REMATCH[1]}"; date="${BASH_REMATCH[2]}"; author=""
+  elif [[ ${dir_name} =~ ${regex_5} ]]; then
     author="${BASH_REMATCH[1]}"; title="${BASH_REMATCH[2]}"; date=""
   else
     echo -e "${COLORS[INFO]}No matching pattern for directory name.${NC}"

--- a/m4bulk.sh
+++ b/m4bulk.sh
@@ -46,7 +46,7 @@
 # - Logs for each audiobook conversion will be saved in the same directory as the source audiobooks.
 # - Customize worker threads and m4bify options to optimize for system resources and project requirements.
 
-readonly VERSION="v0.3.3"
+readonly VERSION="v0.3.4"
 
 # Color schema for pretty print
 readonly NC='\033[0m'           # No Color


### PR DESCRIPTION
### Description

This update introduces functionality to parse directory names following specific patterns to extract audiobook metadata such as author name, book title, and year.

### Supported Patterns

The directory name patterns supported for parsing include the following:
- `<author_name> - <book_title> (<year>)`
- `<author_name> - <book_title> [<year>]`
- `<book_title> (<year>)`
- `<book_title> [<year>]`
- `<author_name> - <book_title>`

In addition to the hyphen (`-`), the underscore (`_`) and colon (`:`) are supported.

### Examples

`Ada Lovelace - The Engine of Change (1833)`
- Author: `Ada Lovelace` 
- Title: `The Engine of Change` 
- Year: `1833` 

`The Quantum Universe [2025]`
- Author: (none)  
- Title: `The Quantum Universe`  
- Year: `2025`  

`Isaac Newton - Opticks`
- Author: `Isaac Newton`  
- Title: `Opticks`  
- Year: (none)