### PR TITLE
fix: printf error on line 438 (invalid number)

### DIFF
--- a/m4bify.sh
+++ b/m4bify.sh
@@ -432,7 +432,7 @@ function process_file_as_chapter {
     convert "${file}" "${output_m4a}" "${bitrate}" "${rel_path}"
 
     # Format the timestamp with hours potentially exceeding 24
-    timestamp=$(printf "%02d:%02d:%06.3f\n" \
+    timestamp=$(LC_NUMERIC="en_US.UTF-8" printf "%02d:%02d:%06.3f\n" \
       "$(echo "${current_time} / 3600" | bc)" \
       "$(echo "${current_time} % 3600 / 60" | bc)" \
       "$(echo "${current_time} % 60" | bc)")


### PR DESCRIPTION
Use "en_US.UTF-8" format to prevent printf error:
m4bify: line 438: printf: 30.117029: invalid number