### PR TITLE
Switch timestamp format to universally available locale

### DIFF
--- a/m4bify.sh
+++ b/m4bify.sh
@@ -470,7 +470,7 @@ function process_file_as_chapter {
     convert "${file}" "${output_m4a}" "${bitrate}" "${rel_path}"
 
     # Format the timestamp with hours potentially exceeding 24
-    timestamp=$(LC_NUMERIC="en_US.UTF-8" printf "%02d:%02d:%06.3f\n" \
+    timestamp=$(LC_NUMERIC="C" printf "%02d:%02d:%06.3f\n" \
       "$(echo "${current_time} / 3600" | bc)" \
       "$(echo "${current_time} % 3600 / 60" | bc)" \
       "$(echo "${current_time} % 60" | bc)")
@@ -527,7 +527,7 @@ function process_dirs_as_chapter {
     done
 
     # Format the timestamp with hours potentially exceeding 24
-    timestamp=$(LC_NUMERIC="en_US.UTF-8" printf "%02d:%02d:%06.3f\n" \
+    timestamp=$(LC_NUMERIC="C" printf "%02d:%02d:%06.3f\n" \
       "$(echo "${current_time} / 3600" | bc)" \
       "$(echo "${current_time} % 3600 / 60" | bc)" \
       "$(echo "${current_time} % 60" | bc)")


### PR DESCRIPTION
### Description 

Minimal safe fix is to switch to the universally available locale LC_NUMERIC="C"

### Related issues

Closes #47 